### PR TITLE
fix: release workflow build errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         run: >
           GOOS=${{ matrix.goos }}
           GOARCH=${{ matrix.goarch }}
-          go build -o ableton-dmx-server-${{ matrix.suffix }}${{ matrix.ext || '' }} ./...
+          go build -o ableton-dmx-server-${{ matrix.suffix }}${{ matrix.ext || '' }} .
         working-directory: server
       - uses: actions/upload-artifact@v4
         with:
@@ -110,7 +110,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter device-scripts build
-      - run: pnpm pack
+      - run: pnpm run pack
       - uses: actions/upload-artifact@v4
         with:
           name: device-amxd

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
     desc: Build Go server and fake emitter
     deps: [build:ui]  # UI must be built first for embed.FS
     cmds:
-      - go build -o ableton-dmx-server ./...
+      - go build -o ableton-dmx-server .
       - cd ../{{.EMITTER_DIR}} && go build ./...
     dir: '{{.SERVER_DIR}}'
     sources:
@@ -220,12 +220,12 @@ tasks:
     desc: Build release artifacts (all platforms)
     deps: [build:ui]
     cmds:
-      - GOOS=darwin  GOARCH=arm64 go build -o ableton-dmx-server-mac-arm64     ./...
-      - GOOS=darwin  GOARCH=amd64 go build -o ableton-dmx-server-mac-amd64     ./...
-      - GOOS=linux   GOARCH=arm64 go build -o ableton-dmx-server-linux-arm64   ./...
-      - GOOS=linux   GOARCH=amd64 go build -o ableton-dmx-server-linux-amd64   ./...
-      - GOOS=windows GOARCH=arm64 go build -o ableton-dmx-server-windows-arm64.exe ./...
-      - GOOS=windows GOARCH=amd64 go build -o ableton-dmx-server-windows-amd64.exe ./...
+      - GOOS=darwin  GOARCH=arm64 go build -o ableton-dmx-server-mac-arm64     .
+      - GOOS=darwin  GOARCH=amd64 go build -o ableton-dmx-server-mac-amd64     .
+      - GOOS=linux   GOARCH=arm64 go build -o ableton-dmx-server-linux-arm64   .
+      - GOOS=linux   GOARCH=amd64 go build -o ableton-dmx-server-linux-amd64   .
+      - GOOS=windows GOARCH=arm64 go build -o ableton-dmx-server-windows-arm64.exe .
+      - GOOS=windows GOARCH=amd64 go build -o ableton-dmx-server-windows-amd64.exe .
     dir: '{{.SERVER_DIR}}'
 
   release:electron:


### PR DESCRIPTION
Fixes two bugs in the release workflow that caused all build jobs to fail on the v0.0.0 tag run.

- `go build .` instead of `go build ./...` — `./...` matches all packages in `server/` and Go rejects `-o filename` when multiple packages are targeted; `.` builds only the `main` package
- `pnpm run pack` instead of `pnpm pack` — `pnpm pack` is a pnpm built-in that creates a `.tgz` tarball; `pnpm run pack` invokes the `pack` script from `package.json` which calls `scripts/pack.sh`

Same fixes applied to `Taskfile.yml` `release:build` and `build:go` for consistency.