### PR TITLE
feat: WLED device health probing via HTTP

### DIFF
--- a/packages/protocol-types/index.ts
+++ b/packages/protocol-types/index.ts
@@ -31,6 +31,7 @@ export interface DiffMessage {
 export interface UniverseStatus {
   label: string
   ip: string
+  online: boolean
 }
 
 /** Connection and universe health */

--- a/server/main.go
+++ b/server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/footgunz/penumbra/e131"
 	"github.com/footgunz/penumbra/state"
 	"github.com/footgunz/penumbra/udp"
+	"github.com/footgunz/penumbra/wled"
 	"github.com/footgunz/penumbra/ws"
 )
 
@@ -41,6 +42,11 @@ func main() {
 	})
 
 	go receiver.Listen()
+
+	prober := wled.NewProber(cfg, func(id string, online bool) {
+		hub.SetUniverseOnline(id, online)
+	})
+	go prober.Run()
 
 	router := api.NewRouter(hub, cfg, wsPort)
 	log.Printf("Listening on :%d (UDP) and :%d (HTTP/WS)", udpPort, wsPort)

--- a/server/wled/probe.go
+++ b/server/wled/probe.go
@@ -1,0 +1,66 @@
+// Package wled provides health probing for WLED devices.
+// It periodically GETs /json/info on each configured universe IP and notifies
+// callers when online status changes.
+package wled
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/footgunz/penumbra/config"
+)
+
+const (
+	probeInterval = 10 * time.Second
+	probeTimeout  = 3 * time.Second
+)
+
+// Prober probes each configured universe's WLED device and calls onChange
+// whenever a device transitions between online and offline.
+type Prober struct {
+	cfg      *config.Config
+	onChange func(id string, online bool)
+	online   map[string]bool
+	client   *http.Client
+}
+
+// NewProber creates a Prober. Call Run() in a goroutine to start probing.
+func NewProber(cfg *config.Config, onChange func(id string, online bool)) *Prober {
+	return &Prober{
+		cfg:      cfg,
+		onChange: onChange,
+		online:   make(map[string]bool),
+		client:   &http.Client{Timeout: probeTimeout},
+	}
+}
+
+// Run probes all universes immediately, then again every probeInterval. Blocks forever.
+func (p *Prober) Run() {
+	p.probeAll()
+	ticker := time.NewTicker(probeInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		p.probeAll()
+	}
+}
+
+func (p *Prober) probeAll() {
+	for id, u := range p.cfg.Universes {
+		online := p.probe(u.IP)
+		was, seen := p.online[id]
+		if !seen || was != online {
+			p.online[id] = online
+			p.onChange(id, online)
+		}
+	}
+}
+
+func (p *Prober) probe(ip string) bool {
+	resp, err := p.client.Get(fmt.Sprintf("http://%s/json/info", ip))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}

--- a/server/ws/hub.go
+++ b/server/ws/hub.go
@@ -27,10 +27,11 @@ type Hub struct {
 
 	// Internal state mirror — kept in sync by parsing broadcast messages.
 	// Allows sending a full state snapshot to newly connected clients.
-	stateMu   sync.Mutex
-	sessionID string
-	lastState map[string]float64
-	lastTs    int64
+	stateMu       sync.Mutex
+	sessionID     string
+	lastState     map[string]float64
+	lastTs        int64
+	universeOnline map[string]bool
 
 	// Rate-limiter for status broadcasts
 	lastStatus time.Time
@@ -46,12 +47,13 @@ type client struct {
 // NewHub creates an idle Hub. Call Run() in a goroutine to activate it.
 func NewHub(cfg *config.Config) *Hub {
 	return &Hub{
-		clients:    make(map[*client]struct{}),
-		broadcast:  make(chan []byte, 256),
-		register:   make(chan *client),
-		unregister: make(chan *client),
-		cfg:        cfg,
-		lastState:  make(map[string]float64),
+		clients:        make(map[*client]struct{}),
+		broadcast:      make(chan []byte, 256),
+		register:       make(chan *client),
+		unregister:     make(chan *client),
+		cfg:            cfg,
+		lastState:      make(map[string]float64),
+		universeOnline: make(map[string]bool),
 	}
 }
 
@@ -121,9 +123,31 @@ func (h *Hub) MaybebroadcastStatus(sessionID string) {
 	h.mu.Unlock()
 }
 
+// SetUniverseOnline updates the online state for a universe and broadcasts
+// a fresh status message to all connected clients.
+func (h *Hub) SetUniverseOnline(id string, online bool) {
+	h.stateMu.Lock()
+	h.universeOnline[id] = online
+	h.stateMu.Unlock()
+
+	msg := h.buildStatusMessage()
+	h.mu.Lock()
+	for c := range h.clients {
+		select {
+		case c.send <- msg:
+		default:
+		}
+	}
+	h.mu.Unlock()
+}
+
 func (h *Hub) buildStatusMessage() []byte {
 	h.stateMu.Lock()
 	lastSeen := h.lastSeen
+	universeOnline := make(map[string]bool, len(h.universeOnline))
+	for k, v := range h.universeOnline {
+		universeOnline[k] = v
+	}
 	h.stateMu.Unlock()
 
 	connected := !lastSeen.IsZero() && time.Since(lastSeen) < 5*time.Second
@@ -133,12 +157,13 @@ func (h *Hub) buildStatusMessage() []byte {
 	}
 
 	type universeStatus struct {
-		Label string `json:"label"`
-		IP    string `json:"ip"`
+		Label  string `json:"label"`
+		IP     string `json:"ip"`
+		Online bool   `json:"online"`
 	}
 	universes := make(map[string]universeStatus, len(h.cfg.Universes))
 	for id, u := range h.cfg.Universes {
-		universes[id] = universeStatus{Label: u.Label, IP: u.IP}
+		universes[id] = universeStatus{Label: u.Label, IP: u.IP, Online: universeOnline[id]}
 	}
 
 	msg := struct {

--- a/ui/src/components/UniverseList.tsx
+++ b/ui/src/components/UniverseList.tsx
@@ -16,6 +16,9 @@ export function UniverseList({ status }: Props) {
     <div style={styles.list}>
       {entries.map(([id, u]) => (
         <div key={id} style={styles.row}>
+          <span style={{ ...styles.badge, background: u.online ? '#22c55e' : '#555' }}>
+            {u.online ? 'online' : 'offline'}
+          </span>
           <span style={styles.label}>Universe {id}: {u.label}</span>
           <span style={styles.ip}>{u.ip}</span>
         </div>
@@ -37,6 +40,15 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: 12,
+  },
+  badge: {
+    padding: '2px 8px',
+    borderRadius: 4,
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: 600,
+    minWidth: 52,
+    textAlign: 'center',
   },
   label: {
     color: '#ccc',


### PR DESCRIPTION
## Summary

- Adds `server/wled/probe.go`: periodic `GET /json/info` probe per configured universe IP (10s interval, 3s timeout per device)
- Prober calls `hub.SetUniverseOnline(id, online)` only on state transitions — no spurious broadcasts
- Hub tracks per-universe online state and includes it in status messages
- `UniverseList` now shows an **online/offline** badge per universe, backed by actual device reachability rather than E1.31 delivery (which is fire-and-forget multicast with no confirmation)

## Test plan

- [ ] With no WLED devices on the network: universe badges show **offline** within 10s of server start
- [ ] With a WLED device at the configured IP: universe badge shows **online** within 10s
- [ ] Pull WLED power: badge transitions to **offline** within ~13s (next probe cycle + timeout)
- [ ] Restore WLED power: badge transitions back to **online** within 10s
- [ ] Go vet and TypeScript typecheck pass (verified locally)