### PR TITLE
feat: parameter fan-out — one parameter drives multiple DMX channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,23 @@ Universe and parameter mappings live in `server/config.json` and are editable vi
 ```json
 {
   "universes": {
-    "1": { "ip": "192.168.1.101", "label": "stage left" }
+    "1": { "ip": "192.168.1.101", "label": "stage left" },
+    "2": { "ip": "192.168.1.102", "label": "stage right" }
   },
   "parameters": {
-    "track1_dimmer": { "universe": 1, "channel": 1 },
-    "track1_red":    { "universe": 1, "channel": 2 }
+    "track1_dimmer": [{ "universe": 1, "channel": 1 }],
+    "track1_red":    [{ "universe": 1, "channel": 2 }]
   }
 }
+```
+
+Each parameter maps to an **array** of channel targets, so a single parameter can fan out to multiple universes and channels simultaneously:
+
+```json
+"master_dimmer": [
+  { "universe": 1, "channel": 1 },
+  { "universe": 2, "channel": 1 }
+]
 ```
 
 Parameter names match the names you give your Live tracks and devices. The server resolves them dynamically — no recompilation needed when your session changes.

--- a/server/config.json
+++ b/server/config.json
@@ -1,6 +1,11 @@
 {
   "universes": {
-    "1": { "ip": "192.168.1.101", "label": "universe 1" }
+    "1": { "ip": "192.168.1.101", "label": "stage left" }
   },
-  "parameters": {}
+  "parameters": {
+    "track1_dimmer": [{ "universe": 1, "channel": 1 }],
+    "track1_red":    [{ "universe": 1, "channel": 2 }],
+    "track1_green":  [{ "universe": 1, "channel": 3 }],
+    "track1_blue":   [{ "universe": 1, "channel": 4 }]
+  }
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -19,11 +19,15 @@ type UniverseConfig struct {
 	Label string `json:"label"`
 }
 
-// ParameterConfig maps a named parameter to its E1.31 universe and DMX channel.
-type ParameterConfig struct {
+// ChannelTarget identifies a single DMX channel within a universe.
+type ChannelTarget struct {
 	Universe int `json:"universe"`
 	Channel  int `json:"channel"` // 1-indexed DMX channel
 }
+
+// ParameterConfig is the list of DMX targets driven by a single parameter.
+// A parameter may fan out to multiple universes and channels simultaneously.
+type ParameterConfig []ChannelTarget
 
 // Load reads config from path. Returns an empty-but-valid Config if the file does not exist.
 func Load(path string) (*Config, error) {

--- a/server/e131/e131.go
+++ b/server/e131/e131.go
@@ -42,17 +42,19 @@ func (d *Dispatcher) Dispatch(state map[string]float64, cfg *config.Config) {
 	// Build per-universe DMX arrays
 	universes := make(map[int][]byte)
 	for paramName, value := range state {
-		mapping, ok := cfg.Parameters[paramName]
+		targets, ok := cfg.Parameters[paramName]
 		if !ok {
 			continue
 		}
-		u := mapping.Universe
-		if _, exists := universes[u]; !exists {
-			universes[u] = make([]byte, UniverseSize)
-		}
-		ch := mapping.Channel - 1 // channel is 1-indexed
-		if ch >= 0 && ch < UniverseSize {
-			universes[u][ch] = floatToDMX(value)
+		for _, t := range targets {
+			u := t.Universe
+			if _, exists := universes[u]; !exists {
+				universes[u] = make([]byte, UniverseSize)
+			}
+			ch := t.Channel - 1 // channel is 1-indexed
+			if ch >= 0 && ch < UniverseSize {
+				universes[u][ch] = floatToDMX(value)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `ParameterConfig` changes from a single `{universe, channel}` object to `[]ChannelTarget` — a clean break, no backwards compat shim
- E1.31 dispatcher iterates all targets per parameter, writing the same value to every mapped channel across any number of universes
- `server/config.json` updated to the new array format with four example parameters
- README documents the fan-out pattern with a `master_dimmer` example spanning two universes

## Real-world use cases

- Mirror fixtures on opposite sides of a stage from a single Live track
- Zone grouping — one `wash_red` parameter drives all wash lights regardless of which universe they're in
- Same fixture type repeated across multiple universes for bandwidth partitioning

## Test plan

- [ ] Single-target config behaves identically to before
- [ ] Multi-target config writes the same DMX value to both channels (verify with WLED or a DMX analyser)
- [ ] `go vet ./...` passes (verified locally)
- [ ] `POST /api/config` accepts the new array format