### PR TITLE
fix(ws): broadcast status immediately after config update

### DIFF
--- a/server/api/routes.go
+++ b/server/api/routes.go
@@ -55,6 +55,7 @@ func NewRouter(hub *ws.Hub, cfg *config.Config, port int) *http.Server {
 			http.Error(w, "save error", http.StatusInternalServerError)
 			return
 		}
+		hub.BroadcastStatus()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"ok":true}`))

--- a/server/ws/hub.go
+++ b/server/ws/hub.go
@@ -123,13 +123,9 @@ func (h *Hub) MaybebroadcastStatus(sessionID string) {
 	h.mu.Unlock()
 }
 
-// SetUniverseOnline updates the online state for a universe and broadcasts
-// a fresh status message to all connected clients.
-func (h *Hub) SetUniverseOnline(id string, online bool) {
-	h.stateMu.Lock()
-	h.universeOnline[id] = online
-	h.stateMu.Unlock()
-
+// BroadcastStatus sends a status message to all connected clients immediately,
+// without rate limiting. Use after intentional config changes.
+func (h *Hub) BroadcastStatus() {
 	msg := h.buildStatusMessage()
 	h.mu.Lock()
 	for c := range h.clients {
@@ -139,6 +135,15 @@ func (h *Hub) SetUniverseOnline(id string, online bool) {
 		}
 	}
 	h.mu.Unlock()
+}
+
+// SetUniverseOnline updates the online state for a universe and broadcasts
+// a fresh status message to all connected clients.
+func (h *Hub) SetUniverseOnline(id string, online bool) {
+	h.stateMu.Lock()
+	h.universeOnline[id] = online
+	h.stateMu.Unlock()
+	h.BroadcastStatus()
 }
 
 func (h *Hub) buildStatusMessage() []byte {


### PR DESCRIPTION
Closes #13

## Summary

- Add `BroadcastStatus()` to `Hub` — non-rate-limited status broadcast for use after intentional config changes
- Call it from `POST /api/config` after a successful save so connected clients see universe changes without waiting for the next periodic tick
- Refactor `SetUniverseOnline` to use `BroadcastStatus`, removing the duplicated broadcast loop