### PR TITLE
feat: JSON config editor with tab bar navigation

### DIFF
--- a/packages/protocol-types/index.ts
+++ b/packages/protocol-types/index.ts
@@ -30,7 +30,7 @@ export interface DiffMessage {
 
 export interface UniverseStatus {
   label: string
-  ip: string
+  device_ip: string
   online: boolean
 }
 
@@ -47,7 +47,7 @@ export type ServerMessage = SessionMessage | StateMessage | DiffMessage | Status
 // ─── UI → Server ──────────────────────────────────────────────────────────────
 
 export interface UniverseConfig {
-  ip: string
+  device_ip: string
   label: string
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,12 @@ importers:
       '@ableton-dmx/protocol-types':
         specifier: workspace:*
         version: link:../packages/protocol-types
+      '@codemirror/lang-json':
+        specifier: ^6.0.2
+        version: 6.0.2
+      '@uiw/react-codemirror':
+        specifier: ^4.25.5
+        version: 4.25.5(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -284,6 +290,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -298,6 +308,33 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@codemirror/autocomplete@6.20.0':
+    resolution: {integrity: sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==}
+
+  '@codemirror/commands@6.10.2':
+    resolution: {integrity: sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/language@6.12.2':
+    resolution: {integrity: sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==}
+
+  '@codemirror/lint@6.9.4':
+    resolution: {integrity: sha512-ABc9vJ8DEmvOWuH26P3i8FpMWPQkduD9Rvba5iwb6O3hxASgclm3T3krGo8NASXkHCidz6b++LWlzWIUfEPSWw==}
+
+  '@codemirror/search@6.6.0':
+    resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
+
+  '@codemirror/state@6.5.4':
+    resolution: {integrity: sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.39.15':
+    resolution: {integrity: sha512-aCWjgweIIXLBHh7bY6cACvXuyrZ0xGafjQ2VInjp4RM4gMfscK5uESiNdrH0pE+e1lZr2B4ONGsjchl2KsKZzg==}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -726,6 +763,18 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lezer/common@1.5.1':
+    resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
   '@malept/cross-spawn-promise@1.1.1':
     resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
     engines: {node: '>= 10'}
@@ -733,6 +782,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@msgpack/msgpack@3.1.3':
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
@@ -1057,6 +1109,28 @@ packages:
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.5':
+    resolution: {integrity: sha512-2KWS4NqrS9SQzlPs/3sxFhuArvjB3JF6WpsrZqBtGHM5/smCNTULX3lUGeRH+f3mkfMt0k6DR+q0xCW9k+Up5w==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.5':
+    resolution: {integrity: sha512-WUMBGwfstufdbnaiMzQzmOf+6Mzf0IbiOoleexC9ItWcDTJybidLtEi20aP2N58Wn/AQxsd5Otebydaimh7Opw==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -1362,6 +1436,9 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
@@ -1422,6 +1499,9 @@ packages:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2819,6 +2899,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -3050,6 +3133,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -3301,6 +3387,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.28.6': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -3325,6 +3413,64 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@codemirror/autocomplete@6.20.0':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+      '@lezer/common': 1.5.1
+
+  '@codemirror/commands@6.10.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+      '@lezer/common': 1.5.1
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@lezer/json': 1.0.3
+
+  '@codemirror/language@6.12.2':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.4':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+      crelt: 1.0.6
+
+  '@codemirror/search@6.6.0':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+      crelt: 1.0.6
+
+  '@codemirror/state@6.5.4':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.39.15':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -3755,6 +3901,22 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lezer/common@1.5.1': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/lr@1.4.8':
+    dependencies:
+      '@lezer/common': 1.5.1
+
   '@malept/cross-spawn-promise@1.1.1':
     dependencies:
       cross-spawn: 7.0.6
@@ -3767,6 +3929,8 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@msgpack/msgpack@3.1.3': {}
 
@@ -4066,6 +4230,33 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
+
+  '@uiw/codemirror-extensions-basic-setup@4.25.5(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.2)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.15)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/commands': 6.10.2
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.4
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+
+  '@uiw/react-codemirror@4.25.5(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@codemirror/commands': 6.10.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.39.15
+      '@uiw/codemirror-extensions-basic-setup': 4.25.5(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.2)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.15)
+      codemirror: 6.0.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -4474,6 +4665,16 @@ snapshots:
 
   co@4.6.0: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/commands': 6.10.2
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.4
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.15
+
   collect-v8-coverage@1.0.3: {}
 
   color-convert@2.0.1:
@@ -4539,6 +4740,8 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6226,6 +6429,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  style-mod@4.1.3: {}
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -6436,6 +6641,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-keyname@2.2.8: {}
 
   walker@1.0.8:
     dependencies:

--- a/server/api/routes.go
+++ b/server/api/routes.go
@@ -17,6 +17,7 @@ import (
 //
 // Routes:
 //   GET /ws          → WebSocket upgrade
+//   GET /api/config  → Return current config as JSON
 //   POST /api/config → Update universe/parameter mapping and persist
 //   GET /            → Serve embedded Vite/React PWA (ui/dist)
 func NewRouter(hub *ws.Hub, cfg *config.Config, port int) *http.Server {
@@ -25,40 +26,51 @@ func NewRouter(hub *ws.Hub, cfg *config.Config, port int) *http.Server {
 	// WebSocket endpoint
 	mux.HandleFunc("/ws", hub.ServeWS)
 
-	// Config update endpoint
+	// Config endpoint — GET returns current config, POST updates it
 	mux.HandleFunc("/api/config", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
+		switch r.Method {
+		case http.MethodGet:
+			data, err := json.MarshalIndent(cfg, "", "  ")
+			if err != nil {
+				http.Error(w, "marshal error", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(data)
+
+		case http.MethodPost:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "read error", http.StatusBadRequest)
+				return
+			}
+			var update struct {
+				Universes  map[int]config.UniverseConfig     `json:"universes"`
+				Parameters map[string]config.ParameterConfig `json:"parameters"`
+			}
+			if err := json.Unmarshal(body, &update); err != nil {
+				http.Error(w, "invalid JSON", http.StatusBadRequest)
+				return
+			}
+			if update.Universes != nil {
+				cfg.Universes = update.Universes
+			}
+			if update.Parameters != nil {
+				cfg.Parameters = update.Parameters
+			}
+			if err := cfg.Save(); err != nil {
+				log.Printf("api: config save: %v", err)
+				http.Error(w, "save error", http.StatusInternalServerError)
+				return
+			}
+			hub.BroadcastStatus()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"ok":true}`))
+
+		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
 		}
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "read error", http.StatusBadRequest)
-			return
-		}
-		var update struct {
-			Universes  map[string]config.UniverseConfig  `json:"universes"`
-			Parameters map[string]config.ParameterConfig `json:"parameters"`
-		}
-		if err := json.Unmarshal(body, &update); err != nil {
-			http.Error(w, "invalid JSON", http.StatusBadRequest)
-			return
-		}
-		if update.Universes != nil {
-			cfg.Universes = update.Universes
-		}
-		if update.Parameters != nil {
-			cfg.Parameters = update.Parameters
-		}
-		if err := cfg.Save(); err != nil {
-			log.Printf("api: config save: %v", err)
-			http.Error(w, "save error", http.StatusInternalServerError)
-			return
-		}
-		hub.BroadcastStatus()
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true}`))
 	})
 
 	// Serve embedded UI — strip the "dist" prefix so "/" maps to "dist/index.html"

--- a/server/config.json
+++ b/server/config.json
@@ -1,11 +1,42 @@
 {
   "universes": {
-    "1": { "ip": "192.168.1.101", "label": "stage left" }
+    "1": {
+      "device_ip": "192.168.1.101",
+      "label": "stage left"
+    },
+    "2": {
+      "device_ip": "192.168.1.102",
+      "label": "stage right"
+    },
+    "3": {
+      "device_ip": "192.168.1.99",
+      "label": "stage left"
+    }
   },
   "parameters": {
-    "track1_dimmer": [{ "universe": 1, "channel": 1 }],
-    "track1_red":    [{ "universe": 1, "channel": 2 }],
-    "track1_green":  [{ "universe": 1, "channel": 3 }],
-    "track1_blue":   [{ "universe": 1, "channel": 4 }]
+    "track1_blue": [
+      {
+        "universe": 1,
+        "channel": 4
+      }
+    ],
+    "track1_dimmer": [
+      {
+        "universe": 1,
+        "channel": 1
+      }
+    ],
+    "track1_green": [
+      {
+        "universe": 1,
+        "channel": 3
+      }
+    ],
+    "track1_red": [
+      {
+        "universe": 1,
+        "channel": 2
+      }
+    ]
   }
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -8,15 +8,17 @@ import (
 // Config holds universe and parameter mapping.
 // Loaded from config.json at startup; updated via set_config WebSocket message.
 type Config struct {
-	Universes  map[string]UniverseConfig  `json:"universes"`
+	Universes  map[int]UniverseConfig     `json:"universes"`
 	Parameters map[string]ParameterConfig `json:"parameters"`
 	path       string
 }
 
-// UniverseConfig maps a universe number (string key) to its target IP and label.
+// UniverseConfig maps a universe number (integer key) to its WLED device IP and label.
+// DeviceIP is the unicast LAN address used for HTTP health probing — not the E1.31
+// multicast destination, which is derived from the universe number directly.
 type UniverseConfig struct {
-	IP    string `json:"ip"`
-	Label string `json:"label"`
+	DeviceIP string `json:"device_ip"`
+	Label    string `json:"label"`
 }
 
 // ChannelTarget identifies a single DMX channel within a universe.
@@ -32,7 +34,7 @@ type ParameterConfig []ChannelTarget
 // Load reads config from path. Returns an empty-but-valid Config if the file does not exist.
 func Load(path string) (*Config, error) {
 	cfg := &Config{
-		Universes:  make(map[string]UniverseConfig),
+		Universes:  make(map[int]UniverseConfig),
 		Parameters: make(map[string]ParameterConfig),
 		path:       path,
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	go receiver.Listen()
 
-	prober := wled.NewProber(cfg, func(id string, online bool) {
+	prober := wled.NewProber(cfg, func(id int, online bool) {
 		hub.SetUniverseOnline(id, online)
 	})
 	go prober.Run()

--- a/server/wled/probe.go
+++ b/server/wled/probe.go
@@ -20,17 +20,17 @@ const (
 // whenever a device transitions between online and offline.
 type Prober struct {
 	cfg      *config.Config
-	onChange func(id string, online bool)
-	online   map[string]bool
+	onChange func(id int, online bool)
+	online   map[int]bool
 	client   *http.Client
 }
 
 // NewProber creates a Prober. Call Run() in a goroutine to start probing.
-func NewProber(cfg *config.Config, onChange func(id string, online bool)) *Prober {
+func NewProber(cfg *config.Config, onChange func(id int, online bool)) *Prober {
 	return &Prober{
 		cfg:      cfg,
 		onChange: onChange,
-		online:   make(map[string]bool),
+		online:   make(map[int]bool),
 		client:   &http.Client{Timeout: probeTimeout},
 	}
 }
@@ -47,7 +47,7 @@ func (p *Prober) Run() {
 
 func (p *Prober) probeAll() {
 	for id, u := range p.cfg.Universes {
-		online := p.probe(u.IP)
+		online := p.probe(u.DeviceIP)
 		was, seen := p.online[id]
 		if !seen || was != online {
 			p.online[id] = online

--- a/server/ws/hub.go
+++ b/server/ws/hub.go
@@ -31,7 +31,7 @@ type Hub struct {
 	sessionID     string
 	lastState     map[string]float64
 	lastTs        int64
-	universeOnline map[string]bool
+	universeOnline map[int]bool
 
 	// Rate-limiter for status broadcasts
 	lastStatus time.Time
@@ -53,7 +53,7 @@ func NewHub(cfg *config.Config) *Hub {
 		unregister:     make(chan *client),
 		cfg:            cfg,
 		lastState:      make(map[string]float64),
-		universeOnline: make(map[string]bool),
+		universeOnline: make(map[int]bool),
 	}
 }
 
@@ -139,7 +139,7 @@ func (h *Hub) BroadcastStatus() {
 
 // SetUniverseOnline updates the online state for a universe and broadcasts
 // a fresh status message to all connected clients.
-func (h *Hub) SetUniverseOnline(id string, online bool) {
+func (h *Hub) SetUniverseOnline(id int, online bool) {
 	h.stateMu.Lock()
 	h.universeOnline[id] = online
 	h.stateMu.Unlock()
@@ -149,7 +149,7 @@ func (h *Hub) SetUniverseOnline(id string, online bool) {
 func (h *Hub) buildStatusMessage() []byte {
 	h.stateMu.Lock()
 	lastSeen := h.lastSeen
-	universeOnline := make(map[string]bool, len(h.universeOnline))
+	universeOnline := make(map[int]bool, len(h.universeOnline))
 	for k, v := range h.universeOnline {
 		universeOnline[k] = v
 	}
@@ -162,20 +162,20 @@ func (h *Hub) buildStatusMessage() []byte {
 	}
 
 	type universeStatus struct {
-		Label  string `json:"label"`
-		IP     string `json:"ip"`
-		Online bool   `json:"online"`
+		Label    string `json:"label"`
+		DeviceIP string `json:"device_ip"`
+		Online   bool   `json:"online"`
 	}
-	universes := make(map[string]universeStatus, len(h.cfg.Universes))
+	universes := make(map[int]universeStatus, len(h.cfg.Universes))
 	for id, u := range h.cfg.Universes {
-		universes[id] = universeStatus{Label: u.Label, IP: u.IP, Online: universeOnline[id]}
+		universes[id] = universeStatus{Label: u.Label, DeviceIP: u.DeviceIP, Online: universeOnline[id]}
 	}
 
 	msg := struct {
-		Type         string                    `json:"type"`
-		M4LConnected bool                      `json:"m4l_connected"`
-		M4LLastSeen  int64                     `json:"m4l_last_seen"`
-		Universes    map[string]universeStatus  `json:"universes"`
+		Type         string                 `json:"type"`
+		M4LConnected bool                   `json:"m4l_connected"`
+		M4LLastSeen  int64                  `json:"m4l_last_seen"`
+		Universes    map[int]universeStatus  `json:"universes"`
 	}{
 		Type:         "status",
 		M4LConnected: connected,

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,15 +12,17 @@
   },
   "dependencies": {
     "@ableton-dmx/protocol-types": "workspace:*",
+    "@codemirror/lang-json": "^6.0.2",
+    "@uiw/react-codemirror": "^4.25.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "@vitejs/plugin-react": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^8.0.0",
     "typescript": "^5.4.0",
     "vite": "^5.0.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,11 +4,15 @@ import { client } from './ws/client'
 import { StatusBar } from './components/StatusBar'
 import { ParameterGrid } from './components/ParameterGrid'
 import { UniverseList } from './components/UniverseList'
+import { ConfigEditor } from './components/ConfigEditor'
+
+type Tab = 'monitor' | 'configure'
 
 export function App() {
   const [params, setParams] = useState<Record<string, number>>({})
   const [status, setStatus] = useState<StatusMessage | null>(null)
   const [sessionId, setSessionId] = useState<string | null>(null)
+  const [tab, setTab] = useState<Tab>('monitor')
   const pendingDiffs = useRef<Record<string, number>>({})
 
   useEffect(() => {
@@ -58,16 +62,34 @@ export function App() {
   return (
     <div style={styles.root}>
       <StatusBar status={status} sessionId={sessionId} />
-      <div style={styles.body}>
-        <section style={styles.section}>
-          <h2 style={styles.heading}>Parameters</h2>
-          <ParameterGrid params={params} />
-        </section>
-        <section style={styles.section}>
-          <h2 style={styles.heading}>Universes</h2>
-          <UniverseList status={status} />
-        </section>
+      <div style={styles.tabBar}>
+        <button
+          style={tab === 'monitor' ? styles.tabActive : styles.tab}
+          onClick={() => setTab('monitor')}
+        >
+          Monitor
+        </button>
+        <button
+          style={tab === 'configure' ? styles.tabActive : styles.tab}
+          onClick={() => setTab('configure')}
+        >
+          Configure
+        </button>
       </div>
+      {tab === 'monitor' ? (
+        <div style={styles.body}>
+          <section style={styles.section}>
+            <h2 style={styles.heading}>Parameters</h2>
+            <ParameterGrid params={params} />
+          </section>
+          <section style={styles.section}>
+            <h2 style={styles.heading}>Universes</h2>
+            <UniverseList status={status} />
+          </section>
+        </div>
+      ) : (
+        <ConfigEditor />
+      )}
     </div>
   )
 }
@@ -79,6 +101,38 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#eee',
     display: 'flex',
     flexDirection: 'column',
+  },
+  tabBar: {
+    display: 'flex',
+    flexDirection: 'row',
+    borderBottom: '1px solid #222',
+    background: '#0f0f1a',
+  },
+  tab: {
+    background: 'none',
+    border: 'none',
+    borderBottom: '2px solid transparent',
+    color: '#666',
+    cursor: 'pointer',
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: 1,
+    padding: '8px 20px',
+    textTransform: 'uppercase' as const,
+  },
+  tabActive: {
+    background: 'none',
+    border: 'none',
+    borderBottom: '2px solid #6366f1',
+    color: '#eee',
+    cursor: 'pointer',
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: 1,
+    padding: '8px 20px',
+    textTransform: 'uppercase' as const,
   },
   body: {
     display: 'flex',

--- a/ui/src/components/ConfigEditor.tsx
+++ b/ui/src/components/ConfigEditor.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useState } from 'react'
+import CodeMirror, { oneDark } from '@uiw/react-codemirror'
+import { json } from '@codemirror/lang-json'
+
+type SaveState = 'idle' | 'saving' | 'saved' | 'error'
+
+export function ConfigEditor() {
+  const [value, setValue] = useState('')
+  const [saveState, setSaveState] = useState<SaveState>('idle')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/config')
+      .then((r) => {
+        if (!r.ok) throw new Error(`fetch failed: ${r.status}`)
+        return r.text()
+      })
+      .then(setValue)
+      .catch((e: Error) => {
+        setErrorMsg(e.message)
+      })
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    setErrorMsg(null)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(value)
+    } catch (e) {
+      setErrorMsg('Invalid JSON: ' + (e instanceof Error ? e.message : String(e)))
+      return
+    }
+
+    setSaveState('saving')
+    try {
+      const r = await fetch('/api/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(parsed),
+      })
+      if (!r.ok) {
+        const text = await r.text()
+        throw new Error(text.trim() || `HTTP ${r.status}`)
+      }
+      setSaveState('saved')
+      setTimeout(() => setSaveState('idle'), 2000)
+    } catch (e) {
+      setSaveState('error')
+      setErrorMsg(e instanceof Error ? e.message : String(e))
+    }
+  }, [value])
+
+  return (
+    <div style={styles.root}>
+      <div style={styles.toolbar}>
+        <span style={styles.title}>Expert config editor</span>
+        <button
+          style={saveState === 'saving' ? styles.btnDisabled : styles.btn}
+          onClick={handleSave}
+          disabled={saveState === 'saving'}
+        >
+          {saveState === 'saving' ? 'Saving…' : saveState === 'saved' ? 'Saved' : 'Save'}
+        </button>
+      </div>
+      <div style={styles.editor}>
+        <CodeMirror
+          value={value}
+          onChange={setValue}
+          extensions={[json()]}
+          theme={oneDark}
+          style={{ height: '100%', fontSize: 13 }}
+          basicSetup={{ lineNumbers: true, foldGutter: true }}
+        />
+      </div>
+      {errorMsg && <div style={styles.error}>{errorMsg}</div>}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    overflow: 'hidden',
+  },
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '10px 16px',
+    borderBottom: '1px solid #222',
+    background: '#0f0f1a',
+  },
+  title: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: '#888',
+  },
+  btn: {
+    background: '#6366f1',
+    border: 'none',
+    borderRadius: 4,
+    color: '#fff',
+    cursor: 'pointer',
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: 600,
+    padding: '5px 14px',
+  },
+  btnDisabled: {
+    background: '#3b3d6e',
+    border: 'none',
+    borderRadius: 4,
+    color: '#999',
+    cursor: 'not-allowed',
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: 600,
+    padding: '5px 14px',
+  },
+  editor: {
+    flex: 1,
+    overflow: 'auto',
+  },
+  error: {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    background: '#3d1515',
+    borderTop: '1px solid #6b1f1f',
+    color: '#f87171',
+    fontFamily: 'monospace',
+    fontSize: 12,
+    padding: '8px 16px',
+    zIndex: 100,
+  },
+}

--- a/ui/src/components/UniverseList.tsx
+++ b/ui/src/components/UniverseList.tsx
@@ -20,7 +20,7 @@ export function UniverseList({ status }: Props) {
             {u.online ? 'online' : 'offline'}
           </span>
           <span style={styles.label}>Universe {id}: {u.label}</span>
-          <span style={styles.ip}>{u.ip}</span>
+          <span style={styles.ip}>{u.device_ip}</span>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- **GET /api/config** — new endpoint returns current config as indented JSON
- **Tab bar** — Monitor / Configure tabs in App.tsx; Configure renders the new editor
- **ConfigEditor** — CodeMirror JSON editor (one-dark theme, line numbers, fold gutter); fetches config on mount, POSTs on save, cycles through idle → saving → saved states; error banner is `position: fixed` at viewport bottom so it's always visible regardless of scroll depth
- **`device_ip` rename** — `UniverseConfig.IP` → `DeviceIP` / `device_ip` throughout Go and TypeScript to clarify it is the WLED device's unicast LAN address used for HTTP health probing, not the E1.31 multicast destination (which is derived from the universe number)
- **`map[int]` universe keys** — universe map key changed from `string` to `int` in config, api, ws, wled, and main; `json.Unmarshal` now rejects non-integer universe keys at the parse boundary, so the JSON editor enforces the type constraint server-side

## Test plan

- [ ] `go vet ./...` passes
- [ ] `pnpm --filter @ableton-dmx/ui typecheck` passes
- [ ] Run server, open UI — Monitor tab shows parameters and universes as before
- [ ] Switch to Configure tab — current config.json loads in editor
- [ ] Edit JSON, click Save — changes persist and universe list updates immediately
- [ ] Enter invalid JSON (e.g. syntax error), click Save — error banner appears at bottom of viewport
- [ ] Enter a non-integer universe key (e.g. `"foo"`), click Save — server returns 400, error shown