### PR TITLE
feat(monitor): show DMX channel values per universe

### DIFF
--- a/packages/protocol-types/index.ts
+++ b/packages/protocol-types/index.ts
@@ -28,10 +28,17 @@ export interface DiffMessage {
   changes: Record<string, number>
 }
 
+export interface ChannelInfo {
+  channel: number  // DMX channel 1–512
+  param: string    // mapped parameter name
+  value: number    // DMX value 0–255
+}
+
 export interface UniverseStatus {
   label: string
   device_ip: string
   online: boolean
+  channels: ChannelInfo[]
 }
 
 /** Connection and universe health */

--- a/server/ws/hub.go
+++ b/server/ws/hub.go
@@ -3,7 +3,9 @@ package ws
 import (
 	"encoding/json"
 	"log"
+	"math"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -100,10 +102,10 @@ func (h *Hub) Broadcast(msg []byte) {
 	h.broadcast <- msg
 }
 
-// MaybebroadcastStatus sends a status message to all clients, rate-limited to ~1/sec.
+// MaybebroadcastStatus sends a status message to all clients, rate-limited to ~100ms.
 func (h *Hub) MaybebroadcastStatus(sessionID string) {
 	h.stateMu.Lock()
-	if time.Since(h.lastStatus) < time.Second {
+	if time.Since(h.lastStatus) < 100*time.Millisecond {
 		h.stateMu.Unlock()
 		return
 	}
@@ -153,6 +155,10 @@ func (h *Hub) buildStatusMessage() []byte {
 	for k, v := range h.universeOnline {
 		universeOnline[k] = v
 	}
+	lastState := make(map[string]float64, len(h.lastState))
+	for k, v := range h.lastState {
+		lastState[k] = v
+	}
 	h.stateMu.Unlock()
 
 	connected := !lastSeen.IsZero() && time.Since(lastSeen) < 5*time.Second
@@ -161,21 +167,56 @@ func (h *Hub) buildStatusMessage() []byte {
 		lastSeenMs = lastSeen.UnixMilli()
 	}
 
-	type universeStatus struct {
-		Label    string `json:"label"`
-		DeviceIP string `json:"device_ip"`
-		Online   bool   `json:"online"`
+	type channelInfo struct {
+		Channel int    `json:"channel"`
+		Param   string `json:"param"`
+		Value   int    `json:"value"` // DMX value 0–255
 	}
+	type universeStatus struct {
+		Label    string        `json:"label"`
+		DeviceIP string        `json:"device_ip"`
+		Online   bool          `json:"online"`
+		Channels []channelInfo `json:"channels"`
+	}
+
+	// Build per-universe channel lists from current parameter state.
+	universeChannels := make(map[int][]channelInfo)
+	for paramName, targets := range h.cfg.Parameters {
+		value := lastState[paramName] // 0.0 if not yet received
+		dmx := int(math.Round(math.Max(0, math.Min(1, value)) * 255))
+		for _, t := range targets {
+			universeChannels[t.Universe] = append(universeChannels[t.Universe], channelInfo{
+				Channel: t.Channel,
+				Param:   paramName,
+				Value:   dmx,
+			})
+		}
+	}
+	for u := range universeChannels {
+		sort.Slice(universeChannels[u], func(i, j int) bool {
+			return universeChannels[u][i].Channel < universeChannels[u][j].Channel
+		})
+	}
+
 	universes := make(map[int]universeStatus, len(h.cfg.Universes))
 	for id, u := range h.cfg.Universes {
-		universes[id] = universeStatus{Label: u.Label, DeviceIP: u.DeviceIP, Online: universeOnline[id]}
+		channels := universeChannels[id]
+		if channels == nil {
+			channels = []channelInfo{}
+		}
+		universes[id] = universeStatus{
+			Label:    u.Label,
+			DeviceIP: u.DeviceIP,
+			Online:   universeOnline[id],
+			Channels: channels,
+		}
 	}
 
 	msg := struct {
-		Type         string                 `json:"type"`
-		M4LConnected bool                   `json:"m4l_connected"`
-		M4LLastSeen  int64                  `json:"m4l_last_seen"`
-		Universes    map[int]universeStatus  `json:"universes"`
+		Type         string                `json:"type"`
+		M4LConnected bool                  `json:"m4l_connected"`
+		M4LLastSeen  int64                 `json:"m4l_last_seen"`
+		Universes    map[int]universeStatus `json:"universes"`
 	}{
 		Type:         "status",
 		M4LConnected: connected,

--- a/ui/src/components/UniverseList.tsx
+++ b/ui/src/components/UniverseList.tsx
@@ -28,19 +28,47 @@ export function UniverseList({ status }: Props) {
         {onlineCount} / {entries.length} online
       </div>
       {entries.map(([id, u]) => (
-        <div key={id} className="flex items-center gap-3 px-4 min-h-[44px] border-t border-border">
-          <Badge
-            className={cn(
-              'min-w-[52px] justify-center font-semibold',
-              u.online ? 'bg-success text-background' : 'bg-border text-text-muted'
-            )}
-          >
-            {u.online ? 'online' : 'offline'}
-          </Badge>
-          <span className="text-text-dim">
-            Universe {id}: {u.label}
-          </span>
-          <span className="text-text-faint ml-auto">{u.device_ip}</span>
+        <div key={id} className="border-t border-border">
+          <div className="flex items-center gap-3 px-4 min-h-[44px]">
+            <Badge
+              className={cn(
+                'min-w-[52px] justify-center font-semibold',
+                u.online ? 'bg-success text-background' : 'bg-border text-text-muted'
+              )}
+            >
+              {u.online ? 'online' : 'offline'}
+            </Badge>
+            <span className="text-text-dim">
+              Universe {id}: {u.label}
+            </span>
+            <span className="text-text-faint ml-auto">{u.device_ip}</span>
+          </div>
+          {u.channels.length > 0 && (
+            <table className="w-full border-collapse mb-1">
+              <thead>
+                <tr className="text-xs text-text-faint">
+                  <th className="text-left font-normal pl-6 pr-2 pb-1 w-12">Ch</th>
+                  <th className="text-left font-normal pr-2 pb-1">Parameter</th>
+                  <th className="text-right font-normal pr-4 pb-1 w-20">DMX</th>
+                  <th className="text-right font-normal pr-4 pb-1 w-16">%</th>
+                </tr>
+              </thead>
+              <tbody>
+                {u.channels.map((ch) => (
+                  <tr key={ch.channel} className="text-xs">
+                    <td className="pl-6 pr-2 py-0.5 text-text-faint tabular-nums">{ch.channel}</td>
+                    <td className="pr-2 py-0.5 text-text-dim font-mono">{ch.param}</td>
+                    <td className="pr-4 py-0.5 text-right tabular-nums text-text">
+                      {ch.value}
+                    </td>
+                    <td className="pr-4 py-0.5 text-right tabular-nums text-text-faint">
+                      {((ch.value / 255) * 100).toFixed(1)}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- Extends `StatusMessage` with per-channel DMX output data so the Monitor tab shows what values are actually being sent to fixtures
- Server computes resolved 0–255 channel values from the current parameter state and config mapping, included in each universe's status
- UI renders a compact channel table (Ch, Parameter, DMX 0–255, %) beneath each universe row
- Status broadcast rate tightened from 1 s to 100 ms for responsive channel monitoring during live operation

## Changes

**`server/ws/hub.go`**
- `buildStatusMessage` now copies `lastState` while holding `stateMu`, then iterates `cfg.Parameters` to compute `int(round(clamp(v) × 255))` per channel target
- Channel lists are sorted by channel number and added as `channels []channelInfo` in each `universeStatus`
- `MaybebroadcastStatus` rate limit: `time.Second` → `100*time.Millisecond`

**`packages/protocol-types/index.ts`**
- New `ChannelInfo` interface: `channel`, `param`, `value`
- `UniverseStatus` gains `channels: ChannelInfo[]`

**`ui/src/components/UniverseList.tsx`**
- Each universe row expands to include a channel table when mappings exist
- Columns: Ch number, parameter name (monospace), DMX value (0–255), percentage

## Test plan

- [ ] `go vet ./...` — passes
- [ ] `go build .` — passes
- [ ] `pnpm typecheck` — passes
- [ ] `pnpm lint` — passes
- [ ] `pnpm test` — passes
- [ ] CI green on push